### PR TITLE
add a partitions argument to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,14 @@ You should have access to an OpenShift cluster and be logged in with the
    $ curl http://`oc get routes/flask-sparkpi2 --template='{{.spec.host}}'`
    Pi is roughly 3.140480
    ```
+
+### Optional parameter
+
+If you would like to change the number of samples that are used to calculate
+Pi, you can specify them by adding the `partitions` argument to your request
+, for example:
+
+```bash
+$ curl http://`oc get routes/flask-sparkpi2 --template='{{.spec.host}}'`/?partitions=10
+Pi is roughly 3.141749
+```

--- a/app.py
+++ b/app.py
@@ -13,8 +13,7 @@ app = Flask(__name__)
 def index():
     spark = SparkSession.builder.appName("PythonPi").getOrCreate()
 
-    # TODO: Need to get this value from querystring 'partitions'
-    partitions = 2
+    partitions = int(request.args.get('partitions', 2))
     n = 100000 * partitions
 
     def f(_):


### PR DESCRIPTION
This change allows the user to specify the number of partitions by
adding an argument to their request. Also updated the readme to include
the partition instructions.