### PR TITLE
add the sparkpi route

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You should have access to an OpenShift cluster and be logged in with the
    ```bash
    oc new-app --template oshinko-pyspark-build-dc  \
        -p APPLICATION_NAME=flask-sparkpi \
-       -p GIT_URI=https://github.com/radanalyticsio/flask-pyspark-pi.git 
+       -p GIT_URI=https://github.com/radanalyticsio/flask-pyspark-pi.git
    ```
 
 1. Expose an external route
@@ -30,6 +30,9 @@ You should have access to an OpenShift cluster and be logged in with the
 1. Visit the exposed URL with your browser or other HTTP tool, for example:
    ```bash
    $ curl http://`oc get routes/flask-sparkpi --template='{{.spec.host}}'`
+   Python Flask SparkPi server running. Add the 'sparkpi' route to this URL to invoke the app.
+
+   $ curl http://`oc get routes/flask-sparkpi --template='{{.spec.host}}'`/sparkpi
    Pi is roughly 3.140480
    ```
 
@@ -40,6 +43,6 @@ Pi, you can specify them by adding the `partitions` argument to your request
 , for example:
 
 ```bash
-$ curl http://`oc get routes/flask-sparkpi --template='{{.spec.host}}'`/?partitions=10
+$ curl http://`oc get routes/flask-sparkpi --template='{{.spec.host}}'`/sparkpi?partitions=10
 Pi is roughly 3.141749
 ```

--- a/app.py
+++ b/app.py
@@ -12,6 +12,11 @@ app = Flask(__name__)
 
 @app.route("/")
 def index():
+    return "Python Flask SparkPi server running. Add the 'sparkpi' route to this URL to invoke the app."
+
+
+@app.route("/sparkpi")
+def sparkpi():
     spark = SparkSession.builder.appName("PythonPi").getOrCreate()
 
     partitions = int(request.args.get('partitions', 2))


### PR DESCRIPTION
This changes the pi calculator exist on the sparkpi endpoint and adds an
informational message about the server at the root endpoint. This brings
the service into alignment with the scala version.