### PR TITLE
modify the produce_pi function to fix import error

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,3 @@
-from random import random
-from operator import add
 import os
 
 from flask import Flask
@@ -15,12 +13,13 @@ def produce_pi(scale):
     n = 100000 * scale
 
     def f(_):
+        from random import random
         x = random()
         y = random()
         return 1 if x ** 2 + y ** 2 <= 1 else 0
 
     count = spark.sparkContext.parallelize(
-        xrange(1, n + 1), scale).map(f).reduce(add)
+        xrange(1, n + 1), scale).map(f).reduce(lambda x, y: x + y)
     spark.stop()
     pi = 4.0 * count / n
     return pi


### PR DESCRIPTION
This fix is chasing an import error that occurs sometimes when spark
serializes the functions.